### PR TITLE
Don't emit 'end' events until all concurrent transforms are done

### DIFF
--- a/through2-concurrent.js
+++ b/through2-concurrent.js
@@ -51,6 +51,14 @@ module.exports = function concurrentThrough (options, transform, flush) {
     });
   }
 
+  // Provide a default implementation of the 'flush' argument
+  // so that the waiting code below can stay simple
+  if (typeof flush !== 'function') {
+    flush = function (callback) {
+      callback();
+    };
+  }
+
   function _flush (callback) {
     // Ensure that flush isn't called until all transforms are complete 
     if (concurrent === 0) {
@@ -60,7 +68,7 @@ module.exports = function concurrentThrough (options, transform, flush) {
     }
   }
   
-  return through2(options, _transform, (typeof flush === 'function') ? _flush : undefined);
+  return through2(options, _transform, _flush);
 };
 
 module.exports.obj = function (options, transform, flush) {


### PR DESCRIPTION
If a through2-concurrent transform is created without specifying a flush argument, then an 'end' event can be generated before all of the transforms are complete.  

When a flush argument is provided, the through2-concurrent stream will wait for all transforms to complete.

This change makes the behavior consistent with or without the flush argument, always waiting for transforms to complete before emitting an 'end' event.