### PR TITLE
Bump through2 to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "underscore": "^1.8.2"
   },
   "dependencies": {
-    "through2": "^0.6.3"
+    "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
The latest stable [through2](https://github.com/rvagg/through2) uses Streams3 (similar to the latest node/io.js).

This change requires a minor version bump. (I agree on this comment. https://github.com/maxogden/concat-stream/pull/36#issuecomment-112649547)
